### PR TITLE
Add tool to sync react native dependencies #20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Expo doctor
         run: bunx expo-doctor
 
+      - name: Check dependency alignment
+        run: bun run check-deps
+
       - name: Build app bundles
         run: bunx expo export --platform all --output-dir dist --non-interactive
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "zustand": "^5.0.11",
       },
       "devDependencies": {
+        "@rnx-kit/align-deps": "^3.4.2",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -454,6 +455,22 @@
     "@react-navigation/native-stack": ["@react-navigation/native-stack@7.14.2", "", { "dependencies": { "@react-navigation/elements": "^2.9.8", "color": "^4.2.3", "sf-symbols-typescript": "^2.1.0", "warn-once": "^0.1.1" }, "peerDependencies": { "@react-navigation/native": "^7.1.31", "react": ">= 18.2.0", "react-native": "*", "react-native-safe-area-context": ">= 4.0.0", "react-native-screens": ">= 4.0.0" } }, "sha512-/nKxFAFSUSGV+NSXrXXcWEcGAHdyp8RyWjoGMDzVPdBhjCLblVSgHWx5y4mm+k0de9V1pkjsftUaroP7rQckzw=="],
 
     "@react-navigation/routers": ["@react-navigation/routers@7.5.3", "", { "dependencies": { "nanoid": "^3.3.11" } }, "sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg=="],
+
+    "@rnx-kit/align-deps": ["@rnx-kit/align-deps@3.4.2", "", { "dependencies": { "@rnx-kit/types-kit-config": "^1.0.0", "@rnx-kit/types-node": "^1.0.0" }, "bin": { "rnx-align-deps": "lib/index.js" } }, "sha512-cwxkFNu942XFTHUHhVMYkKOWkNmKWFhF1TRfGb9CRcmDycLAjNbZ91qyICGXlrYhmdf9o4bpR5qb3uNijmionQ=="],
+
+    "@rnx-kit/types-bundle-config": ["@rnx-kit/types-bundle-config@1.0.0", "", { "dependencies": { "@rnx-kit/types-metro-serializer-esbuild": "^1.0.0", "@rnx-kit/types-plugin-cyclic-dependencies": "^1.0.0", "@rnx-kit/types-plugin-duplicates-checker": "^1.0.0", "@rnx-kit/types-plugin-typescript": "^1.0.0" }, "peerDependencies": { "metro": ">=0.83.0" }, "optionalPeers": ["metro"] }, "sha512-nM5EEWr1pvi1bxKLBfHyj5LB5tv5cpRP0e4Pms8OIhIBMdhRJg6JWYDJSZTL57ZB7FigrAXESBYTWi8CjyqTog=="],
+
+    "@rnx-kit/types-kit-config": ["@rnx-kit/types-kit-config@1.0.0", "", { "dependencies": { "@rnx-kit/types-bundle-config": "^1.0.0" } }, "sha512-2ZeAWxgqbnK5rUdty0OeUHn6R9sc8fxSYzjQsa3OYxCwY2ASfKb/8zMr8M7KH2maAU2AQofFi8ud90WPoP9CQQ=="],
+
+    "@rnx-kit/types-metro-serializer-esbuild": ["@rnx-kit/types-metro-serializer-esbuild@1.0.1", "", {}, "sha512-GgSMtc7VHmAdsARLzWFDiLXCP/+S2FQ57Xm7BVpFeyAdYm0vYxhscFqxCAYKgDc4Q7ZzV2DLNg+Z74AyZekeXQ=="],
+
+    "@rnx-kit/types-node": ["@rnx-kit/types-node@1.0.0", "", { "dependencies": { "@rnx-kit/types-kit-config": "^1.0.0" } }, "sha512-MSSb47OqfpcboyLQfSN/UfDk5zeUP7mMGBDbBIGXyhBwkKfHKEhSj/rY32uv8B0qIsxLaQ7o6+QLx2kLKGOd3Q=="],
+
+    "@rnx-kit/types-plugin-cyclic-dependencies": ["@rnx-kit/types-plugin-cyclic-dependencies@1.0.0", "", {}, "sha512-L/Gi2OzKHYJxqe+w9mOnXBu9uhsLi5LvdCf1Xu/xSWOlHFG/M20qt22iaAiIlWnHSoDKkNQEmHTrBpKZd43HIQ=="],
+
+    "@rnx-kit/types-plugin-duplicates-checker": ["@rnx-kit/types-plugin-duplicates-checker@1.0.0", "", {}, "sha512-y3JjElRuDe9+jdUQxalLb1nQlhaTpId39Qr4vdXjdOR4Z3/NEi9SUcmxWzgtsIh5rwaq/1AXDsSx7llEEASEjg=="],
+
+    "@rnx-kit/types-plugin-typescript": ["@rnx-kit/types-plugin-typescript@1.0.0", "", {}, "sha512-5zFk5wPiAEinfT5XH+t7Ka5I/CUnRf/fqnCS7LDj21ReOgGfdrUQ1wXVsV7EoClCNCgUHvWFDdWkbNOFeFa60A=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "build:production": "eas build --profile production --platform all",
     "device:register": "eas device:create",
     "deploy": "./scripts/build.sh",
-    "test": "bun test"
+    "test": "bun test",
+    "check-deps": "rnx-align-deps --diff-mode allow-subset",
+    "fix-deps": "rnx-align-deps --diff-mode allow-subset --write"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
@@ -55,6 +57,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@rnx-kit/align-deps": "^3.4.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
@@ -67,5 +70,24 @@
   "private": true,
   "trustedDependencies": [
     "@shopify/react-native-skia"
-  ]
+  ],
+  "rnx-kit": {
+    "kitType": "app",
+    "alignDeps": {
+      "requirements": [
+        "react-native@0.83"
+      ],
+      "capabilities": [
+        "animation",
+        "gestures",
+        "navigation/native",
+        "react",
+        "react-dom",
+        "safe-area",
+        "screens",
+        "storage",
+        "svg"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
**`@rnx-kit/align-deps`** (v3.4.2) — Microsoft's dependency alignment tool, installed as a devDependency with this configuration:

- **`rnx-kit` config in `package.json`** — Targets `react-native@0.83` and validates 9 capabilities: `animation` (reanimated), `gestures`, `navigation/native`, `react`, `react-dom`, `safe-area`, `screens`, `storage` (async-storage), and `svg`
- **`--diff-mode allow-subset`** — Because Expo pins packages with `~` (tilde) ranges while align-deps prefers `^` (caret), this mode accepts tighter ranges as valid subsets instead of flagging false positives
- **`core` capability excluded** — In bare React Native it requires `@react-native-community/cli*` and `@react-native/metro-config` as devDependencies, but Expo bundles these internally. We rely on `expo-doctor` for `react-native` version validation instead

**New scripts:**
- `bun run check-deps` — validates dependency alignment (CI-friendly, exits non-zero on mismatch)
- `bun run fix-deps` — auto-fixes any misaligned versions

**CI integration** — A "Check dependency alignment" step was added to the CI job right after `expo-doctor`.

When you upgrade React Native in the future, just update the `requirements` field to the new version (e.g., `react-native@0.84`) and run `bun run fix-deps` to auto-align all ecosystem packages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a dependency alignment check to the continuous integration pipeline to ensure consistency across the project.
  * Introduced new development scripts for verifying and correcting dependency configurations.
  * Added tooling configuration to support automated dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->